### PR TITLE
Webpack config conflict sorted out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 public/js
-public/index.html
+public/main.html
 npm-debug.log
 
 # OS-specific files

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -23,7 +23,7 @@ module.exports = Object.assign({
     }),
     new HtmlWebpackPlugin({
       template: 'templates/index.html',
-      filename: '../index.html'
+      filename: '../main.html'
     })
   ]
 }, baseConfig);

--- a/src/server.js
+++ b/src/server.js
@@ -26,6 +26,7 @@ if (__DEV__) {
   app.use(webpackHotMiddleware(compiler))
 }
 
+
 app.use(express.static('public'));
 
 //keep this handler on the last position of the stack, it serves the index.html if reloading from any url.
@@ -45,9 +46,10 @@ if (__DEV__) {
   });
 } else {
   app.get('*', function(req, res) {
-    res.sendFile(path.resolve(__dirname, '../public/index.html'))
+    res.sendFile(path.resolve(__dirname, '../public/main.html'))
   });
 }
+
 
 app.listen(port, function(error) {
   if (error) {


### PR DESCRIPTION
After getting a weird behavior with the server in development mode I found out that `express.static` is serving the `index.html` placed in `/public` folder no matter in which mode the server is. This is the proper behavior of the middleware as far as I'm aware of.

Since `npm run build` generates an `index.html` file and places it on the root of `/public` folder, new changes while developing will not be displayed due to the express middleware.

A possible solution is the one that follows. I've changed the name of the `index.html` for `main.html`. Another could be placing the `index.html` file into a folder under `/public` and do the trick in `server.js` to serve it as it was placed in the root of the statics folder.

This isn't the most elegant solution, hence the PR. I think this should be further discussed.